### PR TITLE
Fix `NullPointerException` in finalizer if `FreeWinUSB` has already been called

### DIFF
--- a/WinUSBNet/API/WinUSBDevice.cs
+++ b/WinUSBNet/API/WinUSBDevice.cs
@@ -95,7 +95,7 @@ internal partial class WinUSBDevice : IDisposable
             _addInterfaces = null;
         }
 
-        if (!_winUsbHandle.IsInvalid)
+        if (_winUsbHandle is { IsInvalid: false })
         {
             PInvoke.WinUsb_Free(_winUsbHandle.AsInterfaceHandle());
         }


### PR DESCRIPTION
I noted that it is possible for `FreeWinUSB` to be called multiple times, if a device has an exception when it is being opened. In this scenario, `_winUsbHandle` is null the second time `FreeWinUSB` is called and that causes issues if `FreeWinUsb` is called during a finalizer, as then the finalizer then throws a `NullPointerException`.