### PR TITLE
Use ReadOnlySpan instead of Span for write APIs

### DIFF
--- a/WinUSBNet/API/WinUSBDevice.Public.cs
+++ b/WinUSBNet/API/WinUSBDevice.Public.cs
@@ -248,7 +248,7 @@ internal partial class WinUSBDevice
             throw APIException.Win32("Failed to abort pipe on WinUSB device.");
     }
 
-    public unsafe void WritePipe(int interfaceIndex, byte pipeId, Span<byte> buffer, int offset, int length)
+    public unsafe void WritePipe(int interfaceIndex, byte pipeId, ReadOnlySpan<byte> buffer, int offset, int length)
     {
         uint bytesWritten;
         bool success;

--- a/WinUSBNet/USBPipe.cs
+++ b/WinUSBNet/USBPipe.cs
@@ -126,7 +126,7 @@ public sealed class USBPipe
                 "Length of data to read is outside the buffer boundaries.");
     }
 
-    private void CheckWriteParams(Span<byte> buffer, int offset, int length)
+    private void CheckWriteParams(ReadOnlySpan<byte> buffer, int offset, int length)
     {
         if (!IsOut)
             throw new NotSupportedException("Cannot write to a pipe with IN direction.");
@@ -235,7 +235,7 @@ public sealed class USBPipe
     ///     Writes data from a buffer to the pipe.
     /// </summary>
     /// <param name="buffer">The buffer to write data from. The complete buffer will be written to the device.</param>
-    public void Write(Span<byte> buffer)
+    public void Write(ReadOnlySpan<byte> buffer)
     {
         Write(buffer, 0, buffer.Length);
     }
@@ -246,7 +246,7 @@ public sealed class USBPipe
     /// <param name="buffer">The buffer to write data from.</param>
     /// <param name="offset">The byte offset in <paramref name="buffer" /> from which to begin writing.</param>
     /// <param name="length">The number of bytes to write, starting at offset</param>
-    public void Write(Span<byte> buffer, int offset, int length)
+    public void Write(ReadOnlySpan<byte> buffer, int offset, int length)
     {
         CheckWriteParams(buffer, offset, length);
 


### PR DESCRIPTION
Since the write APIs don't modify the data they pass in, it is more clear, convenient, and accessible to use a `ReadOnlySpan<byte>` instead of a `Span<byte>`. This is obviously an API-breaking change, but it is not a source-breaking change, as everything convertible to Span is also convertible to ReadOnlySpan (and Span is further convertible to ReadOnlySpan).