### PR TITLE
Add netstandard2.0 and net10.0-windows without dropping Framework assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,13 @@ jobs:
       - name: Setup .Net SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
-      - name: Build
-        run: dotnet build -c Release
+      - name: Build and pack
+        run: |
+          dotnet build Nefarius.Drivers.WinUSB.sln -c Release /p:MinVerVersionOverride=5.3.1-local
+          mkdir -p artifacts/packages
+          cp bin/Nefarius.Drivers.WinUSB.5.3.1-local.nupkg artifacts/packages/
+
+      - name: Build package consumers
+        run: dotnet build tests/PackageCompatibility/PackageCompatibility.csproj -c Release

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .Net SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Install XMLDoc2Markdown
         run: dotnet tool install -g Nefarius.Tools.XMLDoc2Markdown

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .Net SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Modify README.md for NuGet
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -226,5 +226,6 @@ pip-log.txt
 
 HelpProject/output
 WinUSBNet/*.nupkg
+artifacts/
 
 /.idea

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # <img src="assets/NSS-128x128.png" align="left" />Nefarius.Drivers.WinUSB
 
 [![.NET](https://github.com/nefarius/Nefarius.Drivers.WinUSB/actions/workflows/build.yml/badge.svg)](https://github.com/nefarius/Nefarius.Drivers.WinUSB/actions/workflows/build.yml)
+![.NET Standard 2.0](https://img.shields.io/badge/.NET%20Standard-2.0-blue)
 ![.NET 4.7.2](https://img.shields.io/badge/.NET-4.7.2-blue)
 ![.NET 4.8](https://img.shields.io/badge/.NET-4.8-blue)
-![.NET 6/7/8](https://img.shields.io/badge/.NET-6%2F7%2F8-blue)
+![.NET 6/7/8/10](https://img.shields.io/badge/.NET-6%2F7%2F8%2F10-blue)
 [![NuGet Version](https://img.shields.io/nuget/v/Nefarius.Drivers.WinUSB)](https://www.nuget.org/packages/Nefarius.Drivers.WinUSB/)
 [![NuGet](https://img.shields.io/nuget/dt/Nefarius.Drivers.WinUSB)](https://www.nuget.org/packages/Nefarius.Drivers.WinUSB/)
 
 Managed wrapper for the [WinUSB APIs](https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/winusb) on
 Microsoft Windows.
+
+The package includes assets for .NET Standard 2.0, .NET 6/7/8/10 (Windows), and .NET Framework 4.7.2/4.8. Referencing it
+from a generic TFM such as `net10.0` selects the .NET Standard 2.0 compatibility asset and avoids `NU1701`. Runtime use
+is still **Windows-only**: invoking WinUSB APIs outside Windows is unsupported and will fail.
+
+.NET Framework 4.7.2 or later is the recommended Framework target. .NET Framework 4.7.1 can consume the .NET Standard
+2.0 asset, but is not a first-class supported runtime.
 
 > *This is a fork of the fantastic [`WinUSBNet`](https://github.com/madwizard-thomas/winusbnet) project by Thomas
 Bleeker and contributors.*

--- a/WinUSBNet/Nefarius.Drivers.WinUSB.csproj
+++ b/WinUSBNet/Nefarius.Drivers.WinUSB.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows;net472-windows;net48-windows</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0-windows;net7.0-windows;net8.0-windows;net10.0-windows;net472-windows;net48-windows</TargetFrameworks>
         <RootNamespace>Nefarius.Drivers.WinUSB</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageTags>WinUSB USB</PackageTags>
@@ -9,7 +9,10 @@
         <PackageId>Nefarius.Drivers.WinUSB</PackageId>
         <IsPackable>true</IsPackable>
         <RepositoryUrl>https://github.com/nefarius/Nefarius.Drivers.WinUSB</RepositoryUrl>
-        <Description>WinUSBNet is a .NET class library that provides easy access to the WinUSB API from C#, VB.NET and other .NET languages.</Description>
+        <Description>WinUSBNet is a .NET class library that provides easy access to the WinUSB API from C#, VB.NET and other .NET languages. Runtime support is Windows-only.</Description>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
+        <EnablePackageValidation>true</EnablePackageValidation>
+        <PackageValidationBaselineVersion>5.3.0</PackageValidationBaselineVersion>
         <Platforms>AnyCPU;x64;x86</Platforms>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
@@ -38,6 +41,9 @@
     </ItemGroup>
     
     <ItemGroup>        
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="MinVer" Version="7.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    </PropertyGroup>
+</Project>

--- a/tests/PackageCompatibility/Compatibility.cs
+++ b/tests/PackageCompatibility/Compatibility.cs
@@ -1,0 +1,8 @@
+using System;
+
+using Nefarius.Drivers.WinUSB;
+
+internal static class Compatibility
+{
+    public static Type DeviceType => typeof(USBDevice);
+}

--- a/tests/PackageCompatibility/Compatibility.cs
+++ b/tests/PackageCompatibility/Compatibility.cs
@@ -1,8 +1,118 @@
 using System;
+#if NET10_0 && !WINDOWS
+using System.IO;
+using System.Text.Json;
+#endif
 
 using Nefarius.Drivers.WinUSB;
 
 internal static class Compatibility
 {
     public static Type DeviceType => typeof(USBDevice);
+
+#if NET10_0 && !WINDOWS
+    internal static readonly (string Tfm, string Asset)[] ExpectedAssets =
+    {
+        ("net471", "lib/netstandard2.0/Nefarius.Drivers.WinUSB.dll"),
+        ("net472", "lib/net472/Nefarius.Drivers.WinUSB.dll"),
+        ("net48", "lib/net48/Nefarius.Drivers.WinUSB.dll"),
+        ("net10.0", "lib/netstandard2.0/Nefarius.Drivers.WinUSB.dll"),
+        ("net10.0-windows", "lib/net10.0-windows7.0/Nefarius.Drivers.WinUSB.dll"),
+    };
+
+    public static int Main(string[] args)
+    {
+        _ = DeviceType;
+
+        string assetsPath = args.Length > 0
+            ? args[0]
+            : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "obj", "project.assets.json"));
+
+        if (!File.Exists(assetsPath))
+        {
+            Console.Error.WriteLine("project.assets.json not found: " + assetsPath);
+            return 1;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        if (!document.RootElement.TryGetProperty("targets", out JsonElement targets))
+        {
+            Console.Error.WriteLine("project.assets.json is missing the 'targets' property.");
+            return 1;
+        }
+
+        bool failed = false;
+        foreach ((string tfm, string expectedAsset) in ExpectedAssets)
+        {
+            if (!TryGetCompileAsset(targets, tfm, out string actualAsset))
+            {
+                Console.Error.WriteLine("No Nefarius.Drivers.WinUSB compile asset found for " + tfm + ".");
+                failed = true;
+                continue;
+            }
+
+            if (!string.Equals(actualAsset, expectedAsset, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine(tfm + " selected '" + actualAsset + "' but expected '" + expectedAsset + "'.");
+                failed = true;
+            }
+        }
+
+        return failed ? 1 : 0;
+    }
+
+    private static bool TryGetCompileAsset(JsonElement targets, string tfm, out string asset)
+    {
+        asset = null;
+
+        if (!TryGetTarget(targets, tfm, out JsonElement tfmTarget))
+        {
+            return false;
+        }
+
+        foreach (JsonProperty package in tfmTarget.EnumerateObject())
+        {
+            if (!package.Name.StartsWith("Nefarius.Drivers.WinUSB/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!package.Value.TryGetProperty("compile", out JsonElement compile))
+            {
+                return false;
+            }
+
+            foreach (JsonProperty compileAsset in compile.EnumerateObject())
+            {
+                if (compileAsset.Name.EndsWith("Nefarius.Drivers.WinUSB.dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    asset = compileAsset.Name;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetTarget(JsonElement targets, string tfm, out JsonElement tfmTarget)
+    {
+        if (targets.TryGetProperty(tfm, out tfmTarget))
+        {
+            return true;
+        }
+
+        foreach (JsonProperty property in targets.EnumerateObject())
+        {
+            if (property.Name.Equals(tfm, StringComparison.OrdinalIgnoreCase))
+            {
+                tfmTarget = property.Value;
+                return true;
+            }
+        }
+
+        tfmTarget = default;
+        return false;
+    }
+#endif
 }

--- a/tests/PackageCompatibility/PackageCompatibility.csproj
+++ b/tests/PackageCompatibility/PackageCompatibility.csproj
@@ -7,6 +7,14 @@
         <RestorePackagesPath>$(MSBuildThisFileDirectory)../../artifacts/nuget-cache</RestorePackagesPath>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <Target Name="AssertSelectedPackageAssets" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net10.0'">
+        <Exec Command="dotnet exec &quot;$(TargetPath)&quot; &quot;$(MSBuildProjectDirectory)/obj/project.assets.json&quot;" />
+    </Target>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
             <PrivateAssets>all</PrivateAssets>

--- a/tests/PackageCompatibility/PackageCompatibility.csproj
+++ b/tests/PackageCompatibility/PackageCompatibility.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net471;net472;net48;net10.0;net10.0-windows</TargetFrameworks>
+        <OutputType>Library</OutputType>
+        <Nullable>disable</Nullable>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <RestorePackagesPath>$(MSBuildThisFileDirectory)../../artifacts/nuget-cache</RestorePackagesPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Nefarius.Drivers.WinUSB" Version="5.3.1-local" />
+    </ItemGroup>
+</Project>

--- a/tests/PackageCompatibility/nuget.config
+++ b/tests/PackageCompatibility/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="local" value="../../artifacts/packages" />
+        <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

Supersedes #57. Thanks to @gotty1337 for reporting the `NU1701` issue when consuming this package from a generic TFM such as `net10.0` while selecting WinUSB on Windows and LibUsb on Linux.

This keeps the existing `net472-windows` and `net48-windows` assets and **adds**:

- `netstandard2.0` as a compile-time fallback for generic TFMs (`net10.0`, `net471`, …)
- `net10.0-windows` as an exact modern Windows asset

Runtime use remains Windows-only. Invoking WinUSB APIs outside Windows is unsupported.

## Validation

- `EnablePackageValidation` compares the packed APIs against the released `5.3.0` package
- CI packs a local test package and compiles consumers for `net471`, `net472`, `net48`, `net10.0`, and `net10.0-windows`
- Verified asset selection:
  - `net471` / `net10.0` → `lib/netstandard2.0` (no `NU1701`)
  - `net472` / `net48` → exact Framework assets
  - `net10.0-windows` → `lib/net10.0-windows7.0`

.NET Framework 4.7.2+ remains the recommended Framework range. `net471` can consume the Standard asset, but is not first-class supported.

## Test plan

- [x] Release build of the multi-targeted library
- [x] Pack and inspect `lib/` assets
- [x] Consumer restore/build for all five TFMs with warnings as errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for .NET Standard 2.0 and .NET 10, expanding compatibility across supported .NET Framework and modern .NET applications.
  - Improved package compatibility validation across .NET Framework 4.7.1–4.8 and .NET 10 Windows and non-Windows targets.

- **Documentation**
  - Updated setup guidance, package asset details, target-framework recommendations, and Windows runtime requirements.

- **Chores**
  - Updated build, documentation, and publishing automation to use the .NET 10 SDK.
  - Improved release package generation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->